### PR TITLE
Add useIOOnMount hooks (first draft for review)

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,15 +3,15 @@
 [![CircleCI](https://img.shields.io/circleci/project/github/reazen/relude-reason-react/master.svg)](https://circleci.com/gh/reazen/relude-reason-react)
 [![npm](https://img.shields.io/npm/v/relude-reason-react.svg)](https://www.npmjs.com/package/relude-reason-react)
 
-## Overview
+# Overview
 
 Relude-based utilities for ReasonReact
 
-## Documentation
+# Documentation
 
-### `ReludeReact.Reducer.useReducer`
+## `ReludeReact.Reducer`
 
-The `ReludeReact.Reducer.useReducer` was inspired by the original/pre-hooks [ReasonReact record API](https://reasonml.github.io/reason-react/docs/fr/jsx-2), and the hooks-based [reason-react-update](https://github.com/bloodyowl/reason-react-update) libray by [Matthias Le Brun (bloodyowl)](https://github.com/bloodyowl).
+The `ReludeReact.Reducer.useReducer` hook was inspired by the original/pre-hooks [ReasonReact record API](https://reasonml.github.io/reason-react/docs/fr/jsx-2), and the hooks-based [reason-react-update](https://github.com/bloodyowl/reason-react-update) libray by [Matthias Le Brun (bloodyowl)](https://github.com/bloodyowl).
 
 `ReludeReact.Reducer.useReducer` is similar to the [React `useReducer` hook](https://reactjs.org/docs/hooks-reference.html#usereducer) with the key difference that the React `useReducer` only allows
 you to change the state, whereas the `ReludeReact.Reducer.useReducer` allows you to both change the state, and to safely emit side effects or `Relude.IO`-based actions, which can result in the emission of further actions.
@@ -44,59 +44,43 @@ type update('action, 'state) =
 Basically, this means that in your `ReludeReact.useReducer` component, for any action that occurs,
 you can respond to the action by doing any of the following things:
 
-```reason
-NoUpdate
-```
+### `NoUpdate`
 
-Don't change the state, and don't perform an side effects or IO-based effects
+Don't change the state, and don't perform an side effects or IO-based effects.  Basically a no-op - useful as a placeholder or to stub out actions prior to providing the implementations.
 
-```reason
-Update(state)
-```
+### `Update(state)`
 
 Update the component state to the given value, but don't perform any side effects or IO-based effects.
 
-```reason
-UpdateWithSideEffect(state, sideEffect)
-```
+### `UpdateWithSideEffect(state, sideEffect)`
 
 Update the component state to the given value, and perform the given side effect (basically a function that is given `state` and `send` and is allowed to perform any type of sync or async side effect, and emit additional actions via `send`, and ultimately return unit `()`.  In this case, the side effect is Uncancelable, which means, there is no way to cancel it later.
 
 These types of side effects are useful for doing things like pushing a history state to navigate to a different URL, doing one-off DOM manipulations, or other types of things you don't want or need to manage or control.
 
-```reason
-SideEffect(sideEffect)
-```
+### `SideEffect(sideEffect)`
 
 Same as `UpdateWithSideEffect`, but with no state update.
 
-```reason
-UpdateWithCancelableSideEffect(state, sideEffect)
-```
+### `UpdateWithCancelableSideEffect(state, sideEffect)`
 
 Same as `UpdateWithSideEffect`, but the side effect can be cancelled via a returned canceler function.
 
-```reason
-CancelableSideEffect(sideEffect)
-```
+### `CancelableSideEffect(sideEffect)`
 
 Same as `UpdateWithCancelableSideEffect`, but with no state update.
 
-```reason
-UpdateWithIO(state, ioOfActionAction)
-```
+### `UpdateWithIO(state, Relude.IO.t(action, action))`
 
 Similar to `UpdateWithSideEffect`, but instead of a function that accepts the side effect context and returns `()`, you return a `Relude.IO.t('action, 'action)`.  An `IO` is a data type which can perform any type of synchronous or asynchronous side effect - see below.  `Relude.IO` is a bi-functior which has a typed error channel, and a typed "success" channel.  In this case the success and error channels are both constrained to the type `'action`, which means that your `IO`, when executed, must produce an `'action` to dispatch on either success or failure.
 
 A common pattern with component actions is to perform some async action (which typically can fail, e.g. an AJAX/fetch call), and then send a new `'action` when the async invocation either succeeds or fails.  This patterns is exactly what's captured by the `Relude.IO.t('action, 'action)` type.  See below for a more illustrative example.
 
-```reason
-IO(ioOfActionAction)
-```
+### `IO(Relude.IO.t(action, action))`
 
 Similar to `UpdateWithIO`, but with no initial state update.
 
-### `Relude.IO` Aside
+#### `Relude.IO` Aside
 
 `Relude.IO` is a data type that can be used to execute side effects in a purely functional way.
 For those coming from the JavaScript world, you can think of `IO` as something similar to a lazy
@@ -107,17 +91,28 @@ mapping/flatMapping results and errors, catching and transforming errors, combin
 
 See [Relude IO documentation](https://reazen.github.io/relude/#/api/IO) for more information.
 
-### `ReludeReact.Effect.useOnMount`
+## `ReludeReact.Effect.useOnMount`
 
 `ReludeReact.useOnMount` is a simple shortcut which allows you to register a simple `unit => unit` function to run when a component is first mounted.  This is typically used to send an initial `'action` into your reducer for initializing the component (e.g. fetch any initial data).
 
-### `ReludeReact.Render` utilities
+## `ReludeReact.Effect.useIOOnMount`
 
-`ReludeReact.Render` contains a variety of useful functions for rendering different data types, to avoid extra boilerplate/noise in your components.  See the code for details.
+`ReludeReact.Effect.useIOOnMount` (and it's variations) allows you to trigger a `Relude.IO`-based action when the component is mounted, and handle the final resulting value (either success or failure) using a side-effect callback.
+
+This could be useful if you need to dispatch a fetch request on mount, and then dispatch some reducer actions on success and/or failure, or if you need to store the result of the fetch request
+in localStorage, etc.
+
+Variations of this function exist which allow different types of result callbacks - i.e. a callback from `Belt.Result.t('a, 'e) => unit`, separate `'a => unit` and `'e => unit` callbacks, etc.
+
+## `ReludeReact.Render` utilities
+
+`ReludeReact.Render` contains a variety of useful functions for rendering different data types, to avoid extra boilerplate/noise in your components.  The purpose of these functions is to try to streamline conditional rendering, so you don't have to write lots of `_ => React.null` cases when rendering conditional values, variants like `Relude.AsyncResult.t('a, 'e)`, etc.
 
 ```reason
 ReludeReact.Render.ifTrue
 ReludeReact.Render.ifTrueLazy
+ReludeReact.Render.ifFalse
+ReludeReact.Render.ifFalseLazy
 ReludeReact.Render.option
 ReludeReact.Render.optionLazy
 ReludeReact.Render.optionIfSome
@@ -147,7 +142,6 @@ Below is a somewhat contrived/simple example of what a `ReludeReact` component m
 
 ```reason
 // AnimalListView.re
-
 module AsyncResult = Relude.AsyncResult;
 module IO = Relude.IO;
 module List = Relude.List;
@@ -169,7 +163,8 @@ type action =
   | FetchAnimalsError(Error.t)
   | ViewCreateForm
   | ViewAnimal(Animal.t)
-  | DeleteAnimal(Animal.t);
+  | DeleteAnimal(Animal.t)
+  | NoOp;
 
 // The reducer function which accepts and action and the current state, and emits
 // an "update" which can do things like updating the state, running raw or IO-based effects
@@ -194,6 +189,8 @@ let reducer =
   | ViewAnimal(_animal) => NoUpdate
 
   | DeleteAnimal(_animal) => NoUpdate
+
+  | NoOp => NoUpdate
   };
 
 // Various inline components
@@ -240,14 +237,21 @@ module Main = {
     <div>
       <h1> {React.string(state.title)} </h1>
       <div>
-        <a
-          href="#"
+        <button
           onClick={e => {
             ReactEvent.Synthetic.preventDefault(e);
             send(ViewCreateForm);
           }}>
           {React.string("Create")}
-        </a>
+        </button>
+        <button
+          href="#"
+          onClick={e => {
+            ReactEvent.Synthetic.preventDefault(e);
+            send(NoOp);
+          }}>
+          {React.string("No-Op Action")}
+        </button>
       </div>
       <AnimalsResult send result={state.animalsResult} />
     </div>;
@@ -263,7 +267,20 @@ let make = () => {
   let (state, send) = ReludeReact.Reducer.useReducer(initialState, reducer);
 
   // Trigger an initialization action on mount
+  // This is just using the send function from our reducer to send an action, which is handled by the reducer
   ReludeReact.Effect.useOnMount(() => send(FetchAnimals));
+
+  // This is just demonstrating triggering an IO action on mount, and handling the result via side-effecting functions
+  // In reality, the IO would probably be making a fetch request, or doing some other async action and then storing or
+  // dispatching the results.
+  ReludeReact.Effect.useIOOnMount(
+    IO.suspend(() => {
+      Js.log("Suspend 42");
+      42;
+    }),
+    intValue => Js.log("Got suspended value: " ++ string_of_int(intValue)),
+    _error => Js.log("Suspend 42 failed"),
+  );
 
   // Render our main view, passing the state and dispatcher function down
   <Main state send />;

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Relude-based utilities for ReasonReact
 
 # Documentation
 
-## `ReludeReact.Reducer`
+## `ReludeReact.Reducer.useReducer` hook
 
 The `ReludeReact.Reducer.useReducer` hook was inspired by the original/pre-hooks [ReasonReact record API](https://reasonml.github.io/reason-react/docs/fr/jsx-2), and the hooks-based [reason-react-update](https://github.com/bloodyowl/reason-react-update) libray by [Matthias Le Brun (bloodyowl)](https://github.com/bloodyowl).
 
@@ -52,21 +52,21 @@ Don't change the state, and don't perform an side effects or IO-based effects.  
 
 Update the component state to the given value, but don't perform any side effects or IO-based effects.
 
-### `UpdateWithSideEffect(state, sideEffect)`
+### `UpdateWithSideEffect(state, {state, send} => unit)`
 
-Update the component state to the given value, and perform the given side effect (basically a function that is given `state` and `send` and is allowed to perform any type of sync or async side effect, and emit additional actions via `send`, and ultimately return unit `()`.  In this case, the side effect is Uncancelable, which means, there is no way to cancel it later.
+Update the component state to the given value, and perform the given side effect (basically a function that is given a context record of `state` and `send` and is allowed to perform any type of sync or async side effect, and emit additional actions via `send`, which is a function of type  `action => unit`, and ultimately return unit `()`.  In this case, the side effect is Uncancelable, which means, there is no way to cancel it later.
 
 These types of side effects are useful for doing things like pushing a history state to navigate to a different URL, doing one-off DOM manipulations, or other types of things you don't want or need to manage or control.
 
-### `SideEffect(sideEffect)`
+### `SideEffect({state, send} => unit)`
 
 Same as `UpdateWithSideEffect`, but with no state update.
 
-### `UpdateWithCancelableSideEffect(state, sideEffect)`
+### `UpdateWithCancelableSideEffect(state, {state, send} => (unit => unit))`
 
 Same as `UpdateWithSideEffect`, but the side effect can be cancelled via a returned canceler function.
 
-### `CancelableSideEffect(sideEffect)`
+### `CancelableSideEffect({state, send} => (unit, unit))`
 
 Same as `UpdateWithCancelableSideEffect`, but with no state update.
 
@@ -91,11 +91,11 @@ mapping/flatMapping results and errors, catching and transforming errors, combin
 
 See [Relude IO documentation](https://reazen.github.io/relude/#/api/IO) for more information.
 
-## `ReludeReact.Effect.useOnMount`
+## `ReludeReact.Effect.useOnMount` hook
 
 `ReludeReact.useOnMount` is a simple shortcut which allows you to register a simple `unit => unit` function to run when a component is first mounted.  This is typically used to send an initial `'action` into your reducer for initializing the component (e.g. fetch any initial data).
 
-## `ReludeReact.Effect.useIOOnMount`
+## `ReludeReact.Effect.useIOOnMount` hook
 
 `ReludeReact.Effect.useIOOnMount` (and it's variations) allows you to trigger a `Relude.IO`-based action when the component is mounted, and handle the final resulting value (either success or failure) using a side-effect callback.
 

--- a/src/ReludeReact_Effect.re
+++ b/src/ReludeReact_Effect.re
@@ -1,9 +1,87 @@
-// Shortcut for registering a hook to run at component mount time
+/**
+ * Registers a callback to run a single time when the component is mounted.
+ * This can be used to dispatch an action for handling in a reducer, or for
+ * doing any other type of side-effect.
+ */
 let useOnMount: (unit => unit) => unit =
   onMount =>
     React.useEffect1(
       () => {
         onMount();
+        None;
+      },
+      [||],
+    );
+
+/**
+ * Registers an IO action to run once when the component is mounted, and a callback to handle
+ * the final Result value.
+ */
+let useIOOnMountWithResult:
+  'a 'e.
+  (Relude.IO.t('a, 'e), Belt.Result.t('a, 'e) => unit) => unit
+ =
+  (io, onDone) =>
+    React.useEffect1(
+      () => {
+        io |> Relude.IO.unsafeRunAsync(onDone);
+        None;
+      },
+      [||],
+    );
+
+/**
+ * Registers an IO action to run once when the component is mounted, and separate callbacks to handle
+ * the final ok value, ignoring any errors that might occur.
+ */
+let useIOOnMountWithOk: 'a 'e. (Relude.IO.t('a, 'e), 'a => unit) => unit =
+  (io, onOk) =>
+    React.useEffect1(
+      () => {
+        io
+        |> Relude.IO.unsafeRunAsync(
+             fun
+             | Ok(a) => onOk(a)
+             | Error(_) => (),
+           );
+        None;
+      },
+      [||],
+    );
+
+/**
+ * Registers an IO action to run once when the component is mounted, and separate callbacks to handle
+ * the final error value, ignoring any successful value that might be produced.
+ */
+let useIOOnMountWithError: 'a 'e. (Relude.IO.t('a, 'e), 'e => unit) => unit =
+  (io, onError) =>
+    React.useEffect1(
+      () => {
+        io
+        |> Relude.IO.unsafeRunAsync(
+             fun
+             | Ok(_) => ()
+             | Error(e) => onError(e),
+           );
+        None;
+      },
+      [||],
+    );
+
+/**
+ * Registers an IO action to run once when the component is mounted, and separate callbacks to handle
+ * the final ok or error value.
+ */
+let useIOOnMount: 'a 'e. (Relude.IO.t('a, 'e), 'a => unit, 'e => unit) => unit =
+  (io, onOk, onError) =>
+    React.useEffect1(
+      () => {
+        io
+        |> Relude.IO.unsafeRunAsync(
+             fun
+             | Ok(a) => onOk(a)
+             | Error(e) => onError(e),
+           );
         None;
       },
       [||],


### PR DESCRIPTION
@mlms13 - I went ahead and add the IO onMount things we were talking about.  What do you think of this initial cut at it?

https://github.com/reazen/relude-reason-react/pull/15/files#diff-374abcce22e87309ee85c969a29de128R14-R87

I made several versions, which offer some different ways of handling the result of the IO - any thoughts on names for these things?  I figured the `(IO.t('a, 'e), 'a => unit, 'e => unit)` one probably the mostly commonly wanted one, so I gave that the default name `useIOOnMount`.

Also, it felt like these should have the `IO` arg first, and the handlers second - not sure if we care about `|>` friendliness for these hook functions.