### PR TITLE
Switch order of reducer arguments (fixes #4)

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,10 +19,10 @@ you to change the state, whereas the `ReludeReact.Reducer.useReducer` allows you
 To use the `ReludeReact.Reducer.useReducer` hook, you must provide a reducer function of the following type:
 
 ```reason
-type reducer('action, 'state) = ('action, 'state) => update('action, 'state);
+type reducer('action, 'state) = ('state, 'action) => update('action, 'state);
 ```
 
-A function that accepts an `'action` and the current `'state`, and returns a value of type `update('action, 'state)`
+A function that accepts the current `'state` and an `'action`, and returns a value of type `update('action, 'state)`
 
 The `update` value is a variant with the following type:
 

--- a/examples/demo/AnimalListView.re
+++ b/examples/demo/AnimalListView.re
@@ -23,7 +23,7 @@ type action =
 // The reducer function which accepts and action and the current state, and emits
 // an "update" which can do things like updating the state, running raw or IO-based effects
 let reducer =
-    (action: action, state: state): ReludeReact.Reducer.update(action, state) =>
+    (state: state, action: action): ReludeReact.Reducer.update(action, state) =>
   switch (action) {
   | FetchAnimals =>
     UpdateWithIO(
@@ -118,7 +118,7 @@ module Main = {
 [@react.component]
 let make = () => {
   // Initialize the ReludeReact reducer
-  let (state, send) = ReludeReact.Reducer.useReducer(initialState, reducer);
+  let (state, send) = ReludeReact.Reducer.useReducer(reducer, initialState);
 
   // Trigger an initialization action on mount
   // This is just using the send function from our reducer to send an action,

--- a/src/ReludeReact_Reducer.re
+++ b/src/ReludeReact_Reducer.re
@@ -20,8 +20,8 @@ type update('action, 'state) =
   | UpdateWithIO('state, SideEffect.Uncancelable.IO.t('action, 'state))
   | IO(SideEffect.Uncancelable.IO.t('action, 'state));
 
-// A reducer function takes the action and current state and returns an update command
-type reducer('action, 'state) = ('action, 'state) => update('action, 'state);
+// A reducer function takes the current state and an action and returns an update command
+type reducer('action, 'state) = ('state, 'action) => update('action, 'state);
 
 // The react useReducer state stores the actual component state, along with a ref array of
 // side effects.  The side effects are collected in the reducer functions, then handled
@@ -31,11 +31,11 @@ type stateAndSideEffects('action, 'state) = {
   sideEffects: ref(array(SideEffect.t('action, 'state))),
 };
 
-let useReducer = (initialState: 'state, reducer: reducer('action, 'state)) => {
+let useReducer = (reducer: reducer('action, 'state), initialState: 'state) => {
   let ({state, sideEffects}, send) =
     React.useReducer(
       ({state, sideEffects} as stateAndSideEffects, action) => {
-        let update = reducer(action, state);
+        let update = reducer(state, action);
 
         switch (update) {
         | NoUpdate => stateAndSideEffects


### PR DESCRIPTION
- Swapped order of `state` and `action` args for the reducer function
- Made `initialState` the second arg to `useReducer`
- Updated docs to reflect this